### PR TITLE
Fix asynchronous commands that should be run sequentially

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Get manageiq.org repo
         run: git clone https://github.com/ManageIQ/manageiq.org
       - name: Build
-        run: cd manageiq.org & exe/miq build all
+        run: cd manageiq.org && exe/miq build all
       - name: Set COMMIT_MESSAGE
         run: create_commit_message.rb >> $GITHUB_ENV
       - name: Deploy


### PR DESCRIPTION
In Bash, single & means run asynchronously, while && means run the second command only if the first succeeds