### PR TITLE
Upgrade build to Ruby 2.7

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.5'
+          ruby-version: '2.7'
           bundler-cache: true
       - name: Get manageiq.org repo
         run: git clone https://github.com/ManageIQ/manageiq.org


### PR DESCRIPTION
There is an issue in CI with building libv8 that has been fixed in a
newer rubygems.  Instead of just upgrading Ruby gems, we might as well
update Ruby itself.

See also ManageIQ/manageiq.org#1092

@jrafanie Please review.